### PR TITLE
module4 simple pod example

### DIFF
--- a/module4/1.simple-pod.MD
+++ b/module4/1.simple-pod.MD
@@ -16,7 +16,7 @@ $ kubectl get po --show-labels -owide -w
 ### Expose svc
 
 ```shell
-$ kubectl expose deploy nginx --selector run=nginx --port=80 --type=NodePort
+$ kubectl expose pod nginx --selector run=nginx --port=80 --type=NodePort
 ```
 
 ### Check svc detail


### PR DESCRIPTION
如果执行kubectl expose deploy nginx --selector run=nginx --port=80 --type=NodePort
会报错，deployment not found
因为kubectl run 默认创建的是pod，不是deploy
kubernetes 1.23.1 测试通过