### PR TITLE
fix how to create deployment afeter k8s v1.18

### DIFF
--- a/module4/1.simple-pod.MD
+++ b/module4/1.simple-pod.MD
@@ -3,8 +3,11 @@
 ### Run nginx as webserver
 
 ```shell
+# We can create deployment by 'run' option before k8s v1.18
 $ kubectl run --image=nginx nginx
 $ kubectl run --image=nginx nginx --restart='Always'
+# We should create deployment by 'create deployment' option after k8s v1.18
+$ kubectl create deployment nginx --image=nginx --port=80
 ```
 
 ### Show running pod
@@ -16,7 +19,10 @@ $ kubectl get po --show-labels -owide -w
 ### Expose svc
 
 ```shell
+# When we create deployment by 'run' option, we use selector 'run=nginx'
 $ kubectl expose deploy nginx --selector run=nginx --port=80 --type=NodePort
+# When we create deployment by 'create deployment' option, we use selector 'app=nginx'
+$ kubectl expose deploy nginx --selector app=nginx --port=80 --type=NodePort
 ```
 
 ### Check svc detail


### PR DESCRIPTION
After k8s v1.18, `kubectl run --image=nginx nginx` just run a pod, not create deployment.
`kubectl expose deploy nginx --selector run=nginx --port=80 --type=NodePort` run error, error info `Error from server (NotFound): deployments.apps "nginx" not found`.

We should use `kubectl create deployment nginx --image=nginx --port=80` to create a deployment.